### PR TITLE
Accept orientation on cfdocumentsection 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+# PDF Extension for Lucee
+
+## Build
+
+### Requirements
+* [Apache Ant](https://ant.apache.org/)
+* Java 8
+
+Run `ant` in the project directory to build.

--- a/source/java/src/org/lucee/extension/pdf/PDFDocument.java
+++ b/source/java/src/org/lucee/extension/pdf/PDFDocument.java
@@ -125,7 +125,11 @@ public abstract class PDFDocument {
 	protected int mimeType = MIMETYPE_OTHER;
 	protected Charset charset = null;
 
-	protected String orientation = ORIENTATION_PORTRAIT;
+	// No default value applied here, because a PDFDocument may represent either
+	// a cfdocument or a cfdocumentsection. We only want the former to have a
+	// default, so we will set it in Document instead, because Document is aware
+	// of the context.
+	protected String orientation = null;
 
 	protected boolean backgroundvisible;
 	protected boolean fontembed = true;
@@ -268,6 +272,15 @@ public abstract class PDFDocument {
 				);
 			throw engine.getExceptionUtil().createApplicationException(err);
 		}
+		setOrientationNoCheck(strOrientation);
+	}
+
+	/**
+	 * Set the orientation, without any parameter checking. Use this when the
+	 * calling method cannot throw exceptions, and be careful!
+	 * @param orientation the orientation to set. ("portrait" or "landscape")
+	 */
+	public void setOrientationNoCheck(String strOrientation) {
 		this.orientation = strOrientation;
 	}
 

--- a/source/java/src/org/lucee/extension/pdf/PDFDocument.java
+++ b/source/java/src/org/lucee/extension/pdf/PDFDocument.java
@@ -4,17 +4,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 package org.lucee.extension.pdf;
 
@@ -120,6 +120,8 @@ public abstract class PDFDocument {
 
 	protected int mimeType = MIMETYPE_OTHER;
 	protected Charset charset = null;
+
+	protected String orientation = "portrait";
 
 	protected boolean backgroundvisible;
 	protected boolean fontembed = true;
@@ -244,9 +246,24 @@ public abstract class PDFDocument {
 		}
 	}
 
+	public String getOrientation() {
+		return this.orientation;
+	}
+
+	/**
+	 * @param orientation the orientation to set
+	 * @throws PageException
+	 */
+	public void setOrientation(String strOrientation) throws PageException {
+		if (!["portrait", "landscape"].contains(strOrientation)) {
+			throw engine.getExceptionUtil().createApplicationException("invalid orientation [" + strOrientation + "], valid orientations are [portrait,landscape]");
+		}
+		this.orientation = strOrientation;
+	}
+
 	/**
 	 * set the value proxyserver Host name or IP address of a proxy server.
-	 * 
+	 *
 	 * @param proxyserver value to set
 	 **/
 	public final void setProxyserver(String proxyserver) {
@@ -257,7 +274,7 @@ public abstract class PDFDocument {
 	 * set the value proxyport The port number on the proxy server from which the object is requested.
 	 * Default is 80. When used with resolveURL, the URLs of retrieved documents that specify a port
 	 * number are automatically resolved to preserve links in the retrieved document.
-	 * 
+	 *
 	 * @param proxyport value to set
 	 **/
 	public final void setProxyport(int proxyport) {
@@ -266,7 +283,7 @@ public abstract class PDFDocument {
 
 	/**
 	 * set the value username When required by a proxy server, a valid username.
-	 * 
+	 *
 	 * @param proxyuser value to set
 	 **/
 	public final void setProxyuser(String proxyuser) {
@@ -275,7 +292,7 @@ public abstract class PDFDocument {
 
 	/**
 	 * set the value password When required by a proxy server, a valid password.
-	 * 
+	 *
 	 * @param proxypassword value to set
 	 **/
 	public final void setProxypassword(String proxypassword) {

--- a/source/java/src/org/lucee/extension/pdf/PDFDocument.java
+++ b/source/java/src/org/lucee/extension/pdf/PDFDocument.java
@@ -85,6 +85,10 @@ public abstract class PDFDocument {
 	public static final Dimension PAGETYPE_B5_JIS = new Dimension(516, 728);
 	public static final Dimension PAGETYPE_CUSTOM = new Dimension(1, 1);
 
+	// orientation
+	public static final String ORIENTATION_LANDSCAPE = "landscape";
+	public static final String ORIENTATION_PORTRAIT = "portrait";
+
 	// encryption
 	public static final int ENC_NONE = 0;
 	public static final int ENC_40BIT = 1;
@@ -121,7 +125,7 @@ public abstract class PDFDocument {
 	protected int mimeType = MIMETYPE_OTHER;
 	protected Charset charset = null;
 
-	protected String orientation = "portrait";
+	protected String orientation = ORIENTATION_PORTRAIT;
 
 	protected boolean backgroundvisible;
 	protected boolean fontembed = true;
@@ -255,8 +259,14 @@ public abstract class PDFDocument {
 	 * @throws PageException
 	 */
 	public void setOrientation(String strOrientation) throws PageException {
-		if (!["portrait", "landscape"].contains(strOrientation)) {
-			throw engine.getExceptionUtil().createApplicationException("invalid orientation [" + strOrientation + "], valid orientations are [portrait,landscape]");
+		if (strOrientation != ORIENTATION_LANDSCAPE && strOrientation != ORIENTATION_PORTRAIT) {
+			String err = String.format(
+					"invalid orientation [%s], valid orientations are [%s,%s]",
+					strOrientation,
+					ORIENTATION_PORTRAIT,
+					ORIENTATION_LANDSCAPE
+				);
+			throw engine.getExceptionUtil().createApplicationException(err);
 		}
 		this.orientation = strOrientation;
 	}

--- a/source/java/src/org/lucee/extension/pdf/tag/Document.java
+++ b/source/java/src/org/lucee/extension/pdf/tag/Document.java
@@ -846,7 +846,9 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 			dim = new Dimension(PDFDocument.toPoint(pagewidth, unitFactor), PDFDocument.toPoint(pageheight, unitFactor));
 		}
 		// page orientation
-		if (orientation.equals("landscape")) dim = new Dimension(dim.height, dim.width);
+		if (orientation.equals(PDFDocument.ORIENTATION_LANDSCAPE)) {
+			dim = new Dimension(dim.height, dim.width);
+		}
 		return dim;
 	}
 

--- a/source/java/src/org/lucee/extension/pdf/tag/Document.java
+++ b/source/java/src/org/lucee/extension/pdf/tag/Document.java
@@ -5,17 +5,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 package org.lucee.extension.pdf.tag;
 
@@ -67,7 +67,6 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 	private Dimension pagetype = PDFDocument.PAGETYPE_LETTER;
 	private double pageheight = 0;
 	private double pagewidth = 0;
-	private boolean isLandscape = false;
 
 	private double unitFactor = PDFDocument.UNIT_FACTOR_IN;
 	private int encryption = PDFDocument.ENC_NONE;
@@ -102,7 +101,6 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 		pagetype = PDFDocument.PAGETYPE_LETTER;
 		pageheight = 0;
 		pagewidth = 0;
-		isLandscape = false;
 		unitFactor = PDFDocument.UNIT_FACTOR_IN;
 		encryption = PDFDocument.ENC_NONE;
 		ownerpassword = null;
@@ -155,7 +153,7 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 
 	/**
 	 * set the value proxyserver Host name or IP address of a proxy server.
-	 * 
+	 *
 	 * @param proxyserver value to set
 	 **/
 	public void setProxyserver(String proxyserver) {
@@ -170,7 +168,7 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 	 * set the value proxyport The port number on the proxy server from which the object is requested.
 	 * Default is 80. When used with resolveURL, the URLs of retrieved documents that specify a port
 	 * number are automatically resolved to preserve links in the retrieved document.
-	 * 
+	 *
 	 * @param proxyport value to set
 	 **/
 	public void setProxyport(double proxyport) {
@@ -179,7 +177,7 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 
 	/**
 	 * set the value username When required by a proxy server, a valid username.
-	 * 
+	 *
 	 * @param proxyuser value to set
 	 **/
 	public void setProxyuser(String proxyuser) {
@@ -188,7 +186,7 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 
 	/**
 	 * set the value password When required by a proxy server, a valid password.
-	 * 
+	 *
 	 * @param proxypassword value to set
 	 **/
 	public void setProxypassword(String proxypassword) {
@@ -294,18 +292,6 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 	public void setPagewidth(double pagewidth) throws PageException {
 		if (pagewidth < 1) throw engine.getExceptionUtil().createApplicationException("pagewidth must be a positive number");
 		this.pagewidth = pagewidth;
-	}
-
-	/**
-	 * @param orientation the orientation to set
-	 * @throws PageException
-	 */
-	public void setOrientation(String strOrientation) throws PageException {
-		strOrientation = trimAndLower(strOrientation);
-		if ("portrait".equals(strOrientation)) isLandscape = false;
-		else if ("landscape".equals(strOrientation)) isLandscape = true;
-		else throw engine.getExceptionUtil().createApplicationException("invalid orientation [" + strOrientation + "], valid orientations are [portrait,landscape]");
-
 	}
 
 	public void setMargin(Object margin) throws PageException {
@@ -686,6 +672,8 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 		PdfReader[] pdfReaders = new PdfReader[pdfDocs.length];
 		Iterator<PDFDocument> it = documents.iterator();
 		int index = 0, pageOffset = 0, count = 0, pages;
+		Dimension dimension = null;
+
 		// generate pdf with pd4ml
 
 		while (it.hasNext()) {
@@ -693,13 +681,17 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 			pdfDocs[index] = it.next();
 			pdfDocs[index].setPageOffset(pageOffset);
 
+			// Set the dimension based on the specified orientation of each PDF doc.
+			// This allows for mixed-orientation PDFs.
+			dimension = getDimension(pdfDocs[index].getOrientation());
+
 			int multiCount = getMultipleHF(pdfDocs[index]);
 			// multiple header/footer
 			if (multiCount > 1) {
 				PdfReader[] tmp = new PdfReader[multiCount];
 				for (int i = 0; i < multiCount; i++) {
 					pdfDocs[index].setHFIndex(i);
-					tmp[i] = new PdfReader(pdfDocs[index].render(getDimension(), unitFactor, pageContext, doHtmlBookmarks));
+					tmp[i] = new PdfReader(pdfDocs[index].render(dimension, unitFactor, pageContext, doHtmlBookmarks));
 				}
 				try {
 					pdfReaders[index] = merge(tmp);
@@ -710,12 +702,11 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 						throw eng.getExceptionUtil()
 								.createApplicationException("attribute evalAtPrint is not fully supported with the classic PDF Engine, please use the regular PDF Engine.");
 					}
-
 					throw eng.getExceptionUtil().createPageRuntimeException(eng.getCastUtil().toPageException(e));
 				}
 			}
 			else {
-				pdfReaders[index] = new PdfReader(pdfDocs[index].render(getDimension(), unitFactor, pageContext, doHtmlBookmarks));
+				pdfReaders[index] = new PdfReader(pdfDocs[index].render(dimension, unitFactor, pageContext, doHtmlBookmarks));
 			}
 			pdfDocs[index].setHFIndex(0);
 
@@ -846,7 +837,7 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 		}
 	}
 
-	private Dimension getDimension() throws PageException {
+	private Dimension getDimension(String orientation) throws PageException {
 		// page size custom
 		Dimension dim = pagetype;
 		if (isCustom(pagetype)) {
@@ -855,7 +846,7 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 			dim = new Dimension(PDFDocument.toPoint(pagewidth, unitFactor), PDFDocument.toPoint(pageheight, unitFactor));
 		}
 		// page orientation
-		if (isLandscape) dim = new Dimension(dim.height, dim.width);
+		if (orientation.equals("landscape")) dim = new Dimension(dim.height, dim.width);
 		return dim;
 	}
 
@@ -868,11 +859,17 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 
 	/**
 	 * sets if has body or not
-	 * 
+	 *
 	 * @param hasBody
 	 */
 	public void hasBody(boolean hasBody) {
 
+	}
+	/**
+	 * @param orientation the orientation to set @throws PageException
+	 */
+	public void setOrientation(String strOrientation) throws PageException {
+		getPDFDocument().setOrientation(strOrientation);
 	}
 
 	public static String trimAndLower(String str) {

--- a/source/java/src/org/lucee/extension/pdf/tag/Document.java
+++ b/source/java/src/org/lucee/extension/pdf/tag/Document.java
@@ -119,8 +119,13 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 
 	@Override
 	public PDFDocument getPDFDocument() {
-		if (_document == null) { // second round this is already existing
+		if (_document == null) {
 			_document = PDFDocument.newInstance(getApplicationSettings().getType());
+
+			// Set default orientation for cfdocument. This happens here, instead of
+			// in PDFDocument's property declarations because we only want to set it for
+			// PDFDocuments that represent top-level cfdocuments, not cfdocumentsections.
+			_document.setOrientationNoCheck(PDFDocument.ORIENTATION_PORTRAIT);
 		}
 		return _document;
 	}
@@ -526,6 +531,12 @@ public final class Document extends BodyTagImpl implements AbsDoc {
 		document.setLocalUrl(getPDFDocument().getLocalUrl());
 		document.setFontDirectory(getPDFDocument().getFontDirectory());
 		document.setFontembed(getPDFDocument().getFontembed() ? PDFDocument.FONT_EMBED_YES : PDFDocument.FONT_EMBED_NO);
+
+		// Apply cfdocument's orientation to cfdocumentsections that don't have one
+		// specified.
+		if (document.getOrientation() == null) {
+			document.setOrientationNoCheck(getPDFDocument().getOrientation());
+		}
 
 		documents.add(document);
 	}

--- a/source/java/src/org/lucee/extension/pdf/tag/DocumentSection.java
+++ b/source/java/src/org/lucee/extension/pdf/tag/DocumentSection.java
@@ -5,17 +5,17 @@
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License as published by the Free Software Foundation; either 
+ * License as published by the Free Software Foundation; either
  * version 2.1 of the License, or (at your option) any later version.
- * 
+ *
  * This library is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
  * Lesser General Public License for more details.
- * 
- * You should have received a copy of the GNU Lesser General Public 
+ *
+ * You should have received a copy of the GNU Lesser General Public
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
- * 
+ *
  **/
 package org.lucee.extension.pdf.tag;
 
@@ -65,7 +65,7 @@ public final class DocumentSection extends BodyTagImpl implements AbsDoc {
 
 	/**
 	 * set the value proxyserver Host name or IP address of a proxy server.
-	 * 
+	 *
 	 * @param proxyserver value to set
 	 **/
 	public void setProxyserver(String proxyserver) {
@@ -76,7 +76,7 @@ public final class DocumentSection extends BodyTagImpl implements AbsDoc {
 	 * set the value proxyport The port number on the proxy server from which the object is requested.
 	 * Default is 80. When used with resolveURL, the URLs of retrieved documents that specify a port
 	 * number are automatically resolved to preserve links in the retrieved document.
-	 * 
+	 *
 	 * @param proxyport value to set
 	 **/
 	public void setProxyport(double proxyport) {
@@ -85,7 +85,7 @@ public final class DocumentSection extends BodyTagImpl implements AbsDoc {
 
 	/**
 	 * set the value username When required by a proxy server, a valid username.
-	 * 
+	 *
 	 * @param proxyuser value to set
 	 **/
 	public void setProxyuser(String proxyuser) {
@@ -94,7 +94,7 @@ public final class DocumentSection extends BodyTagImpl implements AbsDoc {
 
 	/**
 	 * set the value password When required by a proxy server, a valid password.
-	 * 
+	 *
 	 * @param proxypassword value to set
 	 **/
 	public void setProxypassword(String proxypassword) {
@@ -127,6 +127,13 @@ public final class DocumentSection extends BodyTagImpl implements AbsDoc {
 	 */
 	public void setMargintop(double margintop) {
 		getPDFDocument().setMargintop(margintop);
+	}
+
+	/**
+	 * @param orientation the orientation to set @throws PageException
+	 */
+	public void setOrientation(String strOrientation) throws PageException {
+		getPDFDocument().setOrientation(strOrientation);
 	}
 
 	/**
@@ -234,7 +241,7 @@ public final class DocumentSection extends BodyTagImpl implements AbsDoc {
 
 	/**
 	 * sets if has body or not
-	 * 
+	 *
 	 * @param hasBody
 	 */
 	public void hasBody(boolean hasBody) {

--- a/source/tld/tag.tldx
+++ b/source/tld/tag.tldx
@@ -419,6 +419,13 @@ Determines if the contents of the cfdocumentitem tag body has to be evaluated at
 		</attribute>
 		<attribute>
 			<type>string</type>
+			<name>orientation</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<description>is the orientation landscape or portrait</description>
+		</attribute>
+		<attribute>
+			<type>string</type>
 			<name>src</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>


### PR DESCRIPTION
Implements https://luceeserver.atlassian.net/browse/LDEV-2528

This PR allows `cfdocumentsection` to accept an `orientation` attribute, which will apply that orientation to the generated PDF page. This allows for a PDF with pages of mixed orientations.

I've also added a README with build instructions.

cc: @sbleon