### PR TITLE
Added a fix: cfpdf destination attribute to throw a correct error for an empty value in LDEV-4025

### DIFF
--- a/source/java/src/org/lucee/extension/pdf/tag/PDF.java
+++ b/source/java/src/org/lucee/extension/pdf/tag/PDF.java
@@ -366,7 +366,8 @@ public class PDF extends BodyTagImpl {
 	/**
 	 * @param destination the destination to set
 	 */
-	public void setDestination(String destination) {
+	public void setDestination(String destination) throws PageException {
+		if (engine.getStringUtil().isEmpty(destination, true)) throw engine.getExceptionUtil().createApplicationException("Attribute [destination] has an invalid value [" + destination + "], it cannot be empty value");
 		this.destination = engine.getResourceUtil().toResourceNotExisting(pageContext, destination);
 	}
 

--- a/tests/LDEV4025.cfc
+++ b/tests/LDEV4025.cfc
@@ -1,0 +1,41 @@
+component extends="org.lucee.cfml.test.LuceeTestCase" labels="pdf"{
+
+	function beforeAll() {
+		document name="variables.testPDF" overwrite=true {
+			writeoutput("test pdf file");
+		} 
+	}
+
+	function run( testResults, testBox ) {
+		describe("Testcase for LDEV-4025", function( currentSpec ) {
+			it(title="Checking error message for using empty string in cfpdf destination attribute", body=function( currentSpec )  {
+				try {
+					pdf action="addheader" source="#variables.testPDF#" destination="" text="test header";
+				}
+				catch(any e) {
+					var errorMsg = e.message;
+				}
+				expect(errorMsg.find("it cannot be empty value")).toBeGT(0);
+			});
+			it(title="Checking error message for space in cfpdf destination attribute", body=function( currentSpec )  {
+				try {
+					pdf action="addheader" source="#variables.testPDF#" destination="  " text="test header";
+				}
+				catch(any e) {
+					var errorMsg = e.message;
+				}
+				expect(errorMsg.find("it cannot be empty value")).toBeGT(0);
+			});
+			it(title="Checking error message for using the null value in cfpdf destination attribute", body=function( currentSpec )  {
+				try {
+					pdf action="addheader" source="#variables.testPDF#" destination="#nullValue()#" text="test header";
+
+				}
+				catch(any e) {
+					var errorMsg = e.message;
+				}
+				expect(errorMsg.find("it cannot be empty value")).toBeGT(0);
+			});
+		});
+	}
+}


### PR DESCRIPTION
https://luceeserver.atlassian.net/browse/LDEV-4025